### PR TITLE
Add typescript type definitions 

### DIFF
--- a/lib.d.ts
+++ b/lib.d.ts
@@ -1,12 +1,10 @@
 declare module "time-since" {
-  export interface timeSince {
-    since: {
-      millis: number;
-      secs: number;
-      mins: number;
-      hours: number;
-      days: number;
-      weeks: number;
-    };
-  }
+  export function since (timestamp: Date): {
+    "millis": ()=>number,
+    "secs": ()=>number,
+    "mins": ()=>number,
+    "hours": ()=>number,
+    "days": ()=>number,
+    "weeks": ()=>number,
+}
 }

--- a/lib.d.ts
+++ b/lib.d.ts
@@ -1,0 +1,12 @@
+declare module "time-since" {
+  export interface timeSince {
+    since: {
+      millis: number;
+      secs: number;
+      mins: number;
+      hours: number;
+      days: number;
+      weeks: number;
+    };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "Convert timestamps to meaningful seconds, minutes, hours, days and weeks.",
   "main": "lib.js",
+  "types": "lib.d.ts",
   "author": {
     "name": "TomBailey",
     "email": "inbox@tombailey.me"


### PR DESCRIPTION
I've been using this package in a project and found it really useful. 

I'm currently upgrading to typescript and there weren't type definitions, so I created a type definition file and added it to the package.json according to [these instructions](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).

It shouldn't affect people not using typescript, but it will make the package work in typescript without any additional configuration. :)

This is my first time making a pull request! So apologies if I've messed anything up.